### PR TITLE
Transform collection into labels array

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -182,7 +182,6 @@ export class Handler {
       timeScheduled: task.created,
       // TODO: add coalesced info
       jobKind: treeherderConfig.jobKind ? treeherderConfig.jobKind : 'other',
-      labels: treeherderConfig.labels ? treeherderConfig.labels : ['opt'],
       reason: treeherderConfig.reason || "scheduled",
       jobInfo: {
         summary: task.metadata.description,
@@ -208,6 +207,19 @@ export class Handler {
       job.origin.pullRequestID = pushInfo.pushId;
       job.origin.owner = pushInfo.owner;
     }
+
+    // Transform "collection" into an array of labels if task doesn't
+    // define "labels".
+    let labels = treeherderConfig.labels ? treeherderConfig.labels : [];
+    if (!labels.length) {
+      if (!treeherderConfig.collection) {
+        labels = ['opt'];
+      } else {
+        labels = Object.keys(treeherderConfig.collection);
+      }
+    }
+
+    job.labels = labels;
 
     let machine = treeherderConfig.machine || {};
     job.buildMachine = {

--- a/test/create_job_message_test.js
+++ b/test/create_job_message_test.js
@@ -31,15 +31,24 @@ suite('build job message', () => {
   });
 
   test('default opt label', async () => {
-    delete task.extra.treeherder.labels;
+    delete task.extra.treeherder.collection;
 
     let job = await handler.buildMessage(pushInfo, task, status.runId, status);
     assert.deepEqual(job, expected);
   });
 
   test('alternative label', async () => {
-    task.extra.treeherder.labels = ['debug'];
+    task.extra.treeherder.collection = { debug: true };
     expected.labels = ['debug'];
+
+    let job = await handler.buildMessage(pushInfo, task, status.runId, status);
+    assert.deepEqual(job, expected);
+  });
+
+  test('labels take precedence over collection', async () => {
+    task.extra.treeherder.collection = { debug: true };
+    task.extra.treeherder.labels = ['asan'];
+    expected.labels = ['asan'];
 
     let job = await handler.buildMessage(pushInfo, task, status.runId, status);
     assert.deepEqual(job, expected);
@@ -61,7 +70,7 @@ suite('build job message', () => {
   });
 
   test('rerun task', async () => {
-    delete task.extra.treeherder.labels;
+    delete task.extra.treeherder.collection;
 
     let job = await handler.buildMessage(pushInfo, task, status.runId, status);
     assert.deepEqual(job, expected);

--- a/test/fixtures/task.js
+++ b/test/fixtures/task.js
@@ -79,7 +79,9 @@ let taskDefinition = `
             "build": {
                 "platform": "b2g-emu-x86-kk"
             },
-            "labels": ["opt"],
+            "collection": {
+              "opt": true
+            },
             "groupName": "Reftest",
             "groupSymbol": "tc-R",
             "machine": {


### PR DESCRIPTION
Tasks currently define the build type (e.g. opt) as a "collection"
but with the new pulse format these are included as an array of labels.
This allows the existing task defintions to be transformed into the
expected output format.