### PR TITLE
Refrain from sending chunk information

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -237,11 +237,6 @@ export class Handler {
       job.display.groupName = treeherderConfig.groupName;
     }
 
-    if (task.extra.chunks) {
-      job.display.chunkCount = task.extra.chunks.total;
-      job.display.chunkId = task.extra.chunks.current;
-    }
-
     return job;
   }
 

--- a/test/fixtures/job_message.js
+++ b/test/fixtures/job_message.js
@@ -9,9 +9,7 @@ let message = `
         "jobSymbol": "R3",
         "groupSymbol": "tc-R",
         "jobName": "[TC] Dummy Task",
-        "groupName": "Reftest",
-        "chunkId": 3,
-        "chunkCount": 40
+        "groupName": "Reftest"
     },
     "state": "pending",
     "result": "unknown",


### PR DESCRIPTION
This is so that the existing behavior is preserved with displaying symbols.