### PR TITLE
Add support for different version of routing key

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-runtime": "^6.6.1",
     "debug": "^2.1.3",
-    "lodash": "^4.0.0",
+    "lodash": "^4.12.0",
     "promise": "^7.0.4",
     "slugid": "^1.1.0",
     "superagent": "^1.1.0",

--- a/src/util/route_parser.js
+++ b/src/util/route_parser.js
@@ -1,16 +1,43 @@
 // Routing key will be in the form:
-// treeherder.<user/project>|<project>.<revision>.<pushLogId/pullRequestId>
+// treeherder.<version>.<user/project>|<project>.<revision>.<pushLogId/pullRequestId>
 // [0] routing key prefix used for listening to only treeherder relevant messages
-// [1] in the form of user/project for github repos and just project for hg.mozilla.org
-// [2] Top level revision for the push
-// [3] Pull Request ID (github) or Push Log ID (hg.mozilla.org) of the push
+// [1] routing key version
+// [2] in the form of user/project for github repos and just project for hg.mozilla.org
+// [3] Top level revision for the push
+// [4] Pull Request ID (github) or Push Log ID (hg.mozilla.org) of the push
 //     Note: pushes ot a branch on github would not have a PR ID
 export default function parseRoute(route) {
-  if (route.match(/\./g).length < 2) {
-    throw new Error("Route is not of an expected format. Expected: <prefix>.<project>.<revision>");
+  let project, revision, pushId, version;
+  let parsedRoute = route.split('.');
+  let destination = parsedRoute[0];
+  // Assume it's a version 1 routing key
+  if (parsedRoute.length === 3) {
+    version = 'v1';
+  } else {
+    version = parsedRoute[1];
   }
 
-  let [destination, project, revision, pushId] = route.split('.');
+  switch (version) {
+    case 'v1':
+      project = parsedRoute[1];
+      revision = parsedRoute[2];
+      break;
+    case 'v2':
+      project = parsedRoute[2];
+      revision = parsedRoute[3];
+      if (parsedRoute.length === 5) {
+        pushId = parsedRoute[4];
+      }
+      break;
+    default:
+      throw new Error(
+          'Unrecognized treeherder routing key format. Possible formats are:\n' +
+          'v1: <treeherder destination>.<project>.<revision>\n' +
+          'v2: <treeherder destination>.<version>.<user/project>|<project>.<revision>.<pushLogId/pullRequestId>' +
+          `but received: ${route}`
+      );
+  }
+
   let x = {
     destination: destination,
     revision: revision,

--- a/test/fixtures/task.js
+++ b/test/fixtures/task.js
@@ -9,7 +9,7 @@ let taskDefinition = `
     ],
     "requires": "all-completed",
     "routes": [
-        "treeherder.dummyproject.dummya98d9bed366c133ebdf1feb5cf365a3c3703a337.123"
+        "treeherder.v2.dummyproject.dummya98d9bed366c133ebdf1feb5cf365a3c3703a337.123"
     ],
     "priority": "normal",
     "retries": 5,

--- a/test/handle_message_test.js
+++ b/test/handle_message_test.js
@@ -5,7 +5,25 @@ import base from 'taskcluster-base';
 
 suite('handle message', () => {
   test('invalid message - more than one matching route', async () => {
-    let handler = new Handler({prefix: 'foo'});
+    let handler = new Handler({
+      prefix: 'foo',
+      queue: {
+        task: (taskId) => {
+          return {
+            payload: {
+              image: 'foo:latest'
+            },
+            extra: {
+              treeherder: {
+                reason: "scheduled",
+                tier: 1
+              }
+            }
+          };
+        }
+      }
+    });
+
     let err;
 
     try {
@@ -25,29 +43,26 @@ suite('handle message', () => {
     assert(err.message.includes("Could not determine treeherder route"));
   });
 
-  test('message is a rerun', async () => {
-    let handler = new Handler({prefix: 'foo'});
-    let err;
-
-    try {
-      await handler.handleMessage({
-        routes: ['foo.bar', 'foo.thing'],
-        payload: {
-          status: {
-            taskId: 'abc',
-          }
-        }
-      })
-    } catch(e) {
-      err = e;
-    }
-
-    assert(err, 'Error was not thrown');
-    assert(err.message.includes("Could not determine treeherder route"));
-  });
 
   test('invalid message - no matching route', async () => {
-    let handler = new Handler({prefix: 'foo'});
+    let handler = new Handler({
+      prefix: 'foo',
+      queue: {
+        task: (taskId) => {
+          return {
+            payload: {
+              image: 'foo:latest'
+            },
+            extra: {
+              treeherder: {
+                reason: "scheduled",
+                tier: 1
+              }
+            }
+          };
+        }
+      }
+    });
     let err;
 
     try {

--- a/test/route_parsing_test.js
+++ b/test/route_parsing_test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import parseRoute from '../lib/util/route_parser';
 
 suite("route parsing", () => {
-  test("valid format - no push id", async () => {
+  test("valid v1 format", async () => {
     assert.deepEqual(
       parseRoute('treeherder.try.XYZ'),
       {
@@ -15,9 +15,9 @@ suite("route parsing", () => {
     );
   });
 
-  test("valid format - with push id", async () => {
+  test("valid v2 format", async () => {
     assert.deepEqual(
-      parseRoute('treeherder.try.XYZ.234'),
+      parseRoute('treeherder.v2.try.XYZ.234'),
       {
         destination:  'treeherder',
         origin:       'hg.mozilla.org',
@@ -30,7 +30,7 @@ suite("route parsing", () => {
 
   test("valid format - github", async () => {
     assert.deepEqual(
-      parseRoute('treeherder.dummy/try.XYZ.234'),
+      parseRoute('treeherder.v2.dummy/try.XYZ.234'),
       {
         destination:  'treeherder',
         origin:       'github.com',
@@ -45,7 +45,7 @@ suite("route parsing", () => {
   test("invalid format", async () => {
     assert.throws(
       () => { parseRoute('treeherder.try') },
-      /Route is not of an expected format/
+      /Unrecognized treeherder routing key format/
     );
   });
 });


### PR DESCRIPTION
Currently there exists one version of the treeherder routing key
but with the support of publishing job messages via pulse, there is the
necessity to start supporting different versions of the routing key.
For instance, version 1 routing keys will have a revision hash in the
routing key while version 2 will contine the top level commit hash along
with a push log ID if available.