### PR TITLE
Bug 1295949

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -49,7 +49,7 @@ function resultFromRun(run) {
 // displayed on the Treeherder Log Viewer once parsed.
 function createLogReference(queue, taskId, run) {
   let logUrl = `https://queue.taskcluster.net/v1/task/${taskId}` +
-                `/runs/${runId}/artifacts/public/logs/live_backing.log`;
+               `/runs/${run.runId}/artifacts/public/logs/live_backing.log`;
 
   return {
     // XXX: This is a magical name see 1147958 which enables the log viewer.

--- a/src/handler.js
+++ b/src/handler.js
@@ -48,9 +48,8 @@ function resultFromRun(run) {
 // Creates a log entry for Treeherder to retrieve and parse.  This log is
 // displayed on the Treeherder Log Viewer once parsed.
 function createLogReference(queue, taskId, run) {
-  let logUrl = queue.buildUrl(
-    queue.getArtifact, taskId, run.runId, 'public/logs/live_backing.log'
-  );
+  let logUrl = `https://queue.taskcluster.net/v1/task/${taskId}` +
+                `/runs/${runId}/artifacts/public/logs/live_backing.log`;
 
   return {
     // XXX: This is a magical name see 1147958 which enables the log viewer.

--- a/src/transform/artifact_links.js
+++ b/src/transform/artifact_links.js
@@ -38,7 +38,8 @@ export default async function(queue, taskId, runId, job) {
       let link = {
         label: 'artifact uploaded',
         linkText: name,
-        url: queue.buildUrl(queue.getArtifact, taskId, runId, artifact.name)
+        url: `https://queue.taskcluster.net/v1/task/${taskId}` +
+             `/runs/${runId}/artifacts/${artifact.name}`,
       };
       return link;
   });

--- a/test/artifact_links_test.js
+++ b/test/artifact_links_test.js
@@ -8,7 +8,7 @@ suite('artifact link transform', () => {
     let expectedLink = {
       label: 'artifact uploaded',
       linkText: 'test.log',
-      url: 'https://queue.taskcluster.net/v1/123/0/artifacts/public/test.log'
+      url: 'https://queue.taskcluster.net/v1/task/123/runs/0/artifacts/public/test.log'
     };
     let job = {
       jobInfo: {
@@ -18,9 +18,6 @@ suite('artifact link transform', () => {
     let queue = {
       listArtifacts: () => {
         return {artifacts: [{name: 'public/test.log'}]};
-      },
-      buildUrl: (client, taskId, runId, name) => {
-        return `https:\/\/queue.taskcluster.net/v1/${taskId}/${runId}/artifacts/${name}`;
       }
     };
 
@@ -35,12 +32,12 @@ suite('artifact link transform', () => {
       {
         label: 'artifact uploaded',
         linkText: 'test.log',
-        url: 'https://queue.taskcluster.net/v1/123/0/artifacts/public/test.log'
+        url: 'https://queue.taskcluster.net/v1/task/123/runs/0/artifacts/public/test.log'
       },
       {
         label: 'artifact uploaded',
         linkText: 'test.log (1)',
-        url: 'https://queue.taskcluster.net/v1/123/0/artifacts/public/test/test.log'
+        url: 'https://queue.taskcluster.net/v1/task/123/runs/0/artifacts/public/test/test.log'
       }
     ];
     let job = {
@@ -55,9 +52,6 @@ suite('artifact link transform', () => {
             {name: 'public/test.log'},
             {name: 'public/test/test.log'}
           ]};
-      },
-      buildUrl: (client, taskId, runId, name) => {
-        return `https:\/\/queue.taskcluster.net/v1/${taskId}/${runId}/artifacts/${name}`;
       }
     };
 
@@ -70,12 +64,12 @@ suite('artifact link transform', () => {
       {
         label: 'artifact uploaded',
         linkText: 'test.log',
-        url: 'https://queue.taskcluster.net/v1/123/0/artifacts/public/test.log'
+        url: 'https://queue.taskcluster.net/v1/task/123/runs/0/artifacts/public/test.log'
       },
       {
         label: 'artifact uploaded',
         linkText: 'fatal.log',
-        url: 'https://queue.taskcluster.net/v1/123/0/artifacts/public/fatal.log'
+        url: 'https://queue.taskcluster.net/v1/task/123/runs/0/artifacts/public/fatal.log'
       }
     ];
     let job = {
@@ -97,9 +91,6 @@ suite('artifact link transform', () => {
           artifacts: artifact,
           continuationToken: token
         }
-      },
-      buildUrl: (client, taskId, runId, name) => {
-        return `https:\/\/queue.taskcluster.net/v1/${taskId}/${runId}/artifacts/${name}`;
       }
     };
 

--- a/test/handle_task_completed_test.js
+++ b/test/handle_task_completed_test.js
@@ -45,7 +45,7 @@ suite('handle completed job', () => {
     expected.logs = [
       {
         name: "builds-4h",
-        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public%2Flogs%2Flive_backing.log"
+        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public/logs/live_backing.log"
       }
     ];
 

--- a/test/handle_task_exception_test.js
+++ b/test/handle_task_exception_test.js
@@ -45,7 +45,7 @@ suite('handle exception job', () => {
     expected.logs = [
       {
         name: "builds-4h",
-        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public%2Flogs%2Flive_backing.log"
+        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public/logs/live_backing.log"
       }
     ];
 
@@ -77,7 +77,7 @@ suite('handle exception job', () => {
     expected.logs = [
       {
         name: "builds-4h",
-        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public%2Flogs%2Flive_backing.log"
+        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public/logs/live_backing.log"
       }
     ];
 

--- a/test/handle_task_failed_test.js
+++ b/test/handle_task_failed_test.js
@@ -45,7 +45,7 @@ suite('handle failed job', () => {
     expected.logs = [
       {
         name: "builds-4h",
-        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public%2Flogs%2Flive_backing.log"
+        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public/logs/live_backing.log"
       }
     ];
 

--- a/test/handle_task_rerun_test.js
+++ b/test/handle_task_rerun_test.js
@@ -39,7 +39,7 @@ suite('handle rerun job', () => {
     expected.logs = [
       {
         name: "builds-4h",
-        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public%2Flogs%2Flive_backing.log"
+        url: "https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public/logs/live_backing.log"
       }
     ];
 


### PR DESCRIPTION
Maybe one day we'll extend the reference file format to support indicating that a URL parameter doesn't need escaping, but for now this is a decent workaround.

We probably can't change the URL format anyways.
