### PR TITLE
Provide taskId/retryId to TH (bug 1323110) [DO NOT MERGE]

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -196,7 +196,7 @@ export class Handler {
     let job = {
       buildSystem: 'taskcluster',
       owner: task.metadata.owner,
-      taskId: `${slugid.decode(taskId)}/${runId}`,
+      taskId: taskId,
       retryId: runId,
       isRetried: false,
       display: {

--- a/test/fixtures/job_message.js
+++ b/test/fixtures/job_message.js
@@ -3,7 +3,7 @@ let message = `
     "buildSystem": "taskcluster",
     "owner": "dummy-taskcluster-tests@mozilla.com",
     "reason": "scheduled",
-    "taskId": "e5431347-3804-4851-b706-7f24081c31c5/0",
+    "taskId": "5UMTRzgESFG3Bn8kCBwxxQ",
     "retryId": 0,
     "isRetried": false,
     "display": {


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1323110#c7

We can't land this before:
A) Treeherder ingestion does `job_guid = taskId + '/' + retryId`
B) We're ready to accept a break in compatibility, active job symbols will likely be duplicated because of new job_guids.

@camd, @gregarndt, I'm not sure what the criteria for tolerating (B) is. Hopefully there is a time frame like sunday afternoon where we can deploy (A) and (B), both will likely cause duplication of active hob symbols.
Had we done this right when we did the pulse ingestion we could avoided this hard break. And treeherder refactoring to store the taskId/runId would have been an internal thing to treeherder.
It's a lot harder to move treeherder when we have these external things that needs to move to, and both will break compatibility.