### PR TITLE
use monitor.reportError instead of console.log

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -113,9 +113,9 @@ export class Handler {
     this.listener.on('message', async (message) => {
       try {
         await this.monitor.timer('handle-message.time', this.handleMessage(message));
-        this.monitor.timer('handle-message.success');
+        this.monitor.count('handle-message.success');
       } catch(err) {
-        this.monitor.timer('handle-message.failure');
+        this.monitor.count('handle-message.failure');
         this.monitor.reportError(err);
       };
     });

--- a/src/transform/artifact_links.js
+++ b/src/transform/artifact_links.js
@@ -1,12 +1,12 @@
 import path from 'path';
 import taskcluster from 'taskcluster-client';
 
-export default async function(queue, taskId, runId, job) {
+export default async function(queue, monitor, taskId, runId, job) {
   let res;
   try {
     res = await queue.listArtifacts(taskId, runId);
   } catch(e) {
-    console.log(`Error fetching artifacts for ${taskId}, ${e.message}`);
+    monitor.reportError(e, {taskId, runId});
     return job;
   }
 
@@ -18,7 +18,7 @@ export default async function(queue, taskId, runId, job) {
     try {
       res = await queue.listArtifacts(taskId, runId, continuation);
     } catch(e) {
-      console.log(`Error fetching artifacts for ${taskId}, ${e.message}`);
+      monitor.reportError(e, {taskId, runId});
       break;
     }
 

--- a/test/artifact_links_test.js
+++ b/test/artifact_links_test.js
@@ -1,8 +1,19 @@
 import assert from 'assert';
 import { taskDefinition } from './fixtures/task';
+import Monitor from 'taskcluster-lib-monitor';
 import artifactLinkTransform from '../lib/transform/artifact_links';
 
+let monitor;
+
 suite('artifact link transform', () => {
+  suiteSetup(async () => {
+    monitor = await Monitor({
+      project: 'tc-treeherder-test',
+      credentials: {},
+      mock: true
+    });
+  })
+
   test('artifact link added', async () => {
     let links = ['foo'];
     let expectedLink = {
@@ -21,7 +32,7 @@ suite('artifact link transform', () => {
       }
     };
 
-    job = await artifactLinkTransform(queue, '123', 0, job);
+    job = await artifactLinkTransform(queue, monitor, '123', 0, job);
     links.push(expectedLink);
 
     assert.deepEqual(links, job.jobInfo.links);
@@ -55,7 +66,7 @@ suite('artifact link transform', () => {
       }
     };
 
-    job = await artifactLinkTransform(queue, '123', 0, job);
+    job = await artifactLinkTransform(queue, monitor, '123', 0, job);
     assert.deepEqual(expectedLinks, job.jobInfo.links);
   });
 
@@ -94,7 +105,7 @@ suite('artifact link transform', () => {
       }
     };
 
-    job = await artifactLinkTransform(queue, '123', 0, job);
+    job = await artifactLinkTransform(queue, monitor, '123', 0, job);
     assert.deepEqual(expectedLinks, job.jobInfo.links);
   });
 
@@ -109,7 +120,7 @@ suite('artifact link transform', () => {
       listArtifacts: () => { throw new Error('bad things happened') }
     };
 
-    job = await artifactLinkTransform(queue, '123', 0, job);
+    job = await artifactLinkTransform(queue, monitor, '123', 0, job);
     assert.deepEqual(links, job.jobInfo.links);
   });
 });

--- a/test/handle_message_test.js
+++ b/test/handle_message_test.js
@@ -111,24 +111,18 @@ suite('handle message', () => {
         }
       }
     });
-    let err;
 
-    try {
-      await handler.handleMessage({
-        routes: ['foo.bar.123'],
-        payload: {
-          status: {
-            taskId: 'abc',
-          }
+    await handler.handleMessage({
+      routes: ['foo.bar.123'],
+      payload: {
+        status: {
+          taskId: 'abc',
         }
-      })
-    } catch(e) {
-      err = e;
-    }
+      }
+    })
 
-    assert(err, 'Error was not thrown');
     assert(called, 'Task was not retrieved by the queue');
-    assert(err.message.includes("Message is missing Treeherder job configuration"));
+    assert.equal(monitor.counts['tc-treeherder-test.validateTask.no-config'], 1)
   });
 
   test('invalid message - invalid treeherder config', async () => {
@@ -159,22 +153,16 @@ suite('handle message', () => {
         aws:    {}
     });
 
-    let err;
-    try {
-      await handler.handleMessage({
-        routes: ['foo.bar.123'],
-        payload: {
-          status: {
-            taskId: 'abc'
-          }
+    await handler.handleMessage({
+      routes: ['foo.bar.123'],
+      payload: {
+        status: {
+          taskId: 'abc'
         }
-      })
-    } catch(e) {
-      err = e;
-    }
+      }
+    })
 
-    assert(err, 'Error was not thrown');
     assert(called, 'Task was retrieved by the queue');
-    assert(err.message.includes("Message contains an invalid Treeherder job configuration"));
+    assert.equal(monitor.counts['tc-treeherder-test.validateTask.invalid-config'], 1)
   });
 });

--- a/test/handle_task_completed_test.js
+++ b/test/handle_task_completed_test.js
@@ -4,13 +4,22 @@ import { taskDefinition } from './fixtures/task';
 import { statusMessage } from './fixtures/task_status';
 import { jobMessage } from './fixtures/job_message';
 import parseRoute from '../lib/util/route_parser';
+import Monitor from 'taskcluster-lib-monitor';
 import taskcluster from 'taskcluster-client';
 
 let handler, task, status, expected, pushInfo;
 
 suite('handle completed job', () => {
-  beforeEach(() => {
-    handler = new Handler({prefix: 'treeherder', queue: new taskcluster.Queue()});
+  beforeEach(async () => {
+    handler = new Handler({
+      prefix: 'treeherder',
+      queue: new taskcluster.Queue(),
+      monitor: await Monitor({
+        project: 'tc-treeherder-test',
+        credentials: {},
+        mock: true,
+      }),
+    });
     task = JSON.parse(taskDefinition);
     status = JSON.parse(statusMessage);
     expected = JSON.parse(jobMessage);

--- a/test/handle_task_exception_test.js
+++ b/test/handle_task_exception_test.js
@@ -4,13 +4,22 @@ import { taskDefinition } from './fixtures/task';
 import { statusMessage } from './fixtures/task_status';
 import { jobMessage } from './fixtures/job_message';
 import parseRoute from '../lib/util/route_parser';
+import Monitor from 'taskcluster-lib-monitor';
 import taskcluster from 'taskcluster-client';
 
 let handler, task, status, expected, pushInfo;
 
 suite('handle exception job', () => {
-  beforeEach(() => {
-    handler = new Handler({prefix: 'treeherder', queue: new taskcluster.Queue()});
+  beforeEach(async () => {
+    handler = new Handler({
+      prefix: 'treeherder',
+      queue: new taskcluster.Queue(),
+      monitor: await Monitor({
+        project: 'tc-treeherder-test',
+        credentials: {},
+        mock: true,
+      }),
+    });
     task = JSON.parse(taskDefinition);
     status = JSON.parse(statusMessage);
     expected = JSON.parse(jobMessage);

--- a/test/handle_task_failed_test.js
+++ b/test/handle_task_failed_test.js
@@ -4,13 +4,22 @@ import { taskDefinition } from './fixtures/task';
 import { statusMessage } from './fixtures/task_status';
 import { jobMessage } from './fixtures/job_message';
 import parseRoute from '../lib/util/route_parser';
+import Monitor from 'taskcluster-lib-monitor';
 import taskcluster from 'taskcluster-client';
 
 let handler, task, status, expected, pushInfo;
 
 suite('handle failed job', () => {
-  beforeEach(() => {
-    handler = new Handler({prefix: 'treeherder', queue: new taskcluster.Queue()});
+  beforeEach(async () => {
+    handler = new Handler({
+      prefix: 'treeherder',
+      queue: new taskcluster.Queue(),
+      monitor: await Monitor({
+        project: 'tc-treeherder-test',
+        credentials: {},
+        mock: true,
+      }),
+    });
     task = JSON.parse(taskDefinition);
     status = JSON.parse(statusMessage);
     expected = JSON.parse(jobMessage);

--- a/test/handle_task_rerun_test.js
+++ b/test/handle_task_rerun_test.js
@@ -4,13 +4,22 @@ import { taskDefinition } from './fixtures/task';
 import { statusMessage } from './fixtures/task_status';
 import { jobMessage } from './fixtures/job_message';
 import parseRoute from '../lib/util/route_parser';
+import Monitor from 'taskcluster-lib-monitor';
 import taskcluster from 'taskcluster-client';
 
 let handler, task, status, expected, pushInfo;
 
 suite('handle rerun job', () => {
-  beforeEach(() => {
-    handler = new Handler({prefix: 'treeherder', queue: new taskcluster.Queue()});
+  beforeEach(async () => {
+    handler = new Handler({
+      prefix: 'treeherder',
+      queue: new taskcluster.Queue(),
+      monitor: await Monitor({
+        project: 'tc-treeherder-test',
+        credentials: {},
+        mock: true,
+      }),
+    });
     task = JSON.parse(taskDefinition);
     status = JSON.parse(statusMessage);
     expected = JSON.parse(jobMessage);


### PR DESCRIPTION
I came to try to use the fake PulseListener for testing, but you've already mocked out the listener very nicely.  So I cleaned up the console.log's :)