### PR TITLE
Bug 1328947 - Remove jobinfo "links"

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -225,19 +225,7 @@ export class Handler {
       jobKind: treeherderConfig.jobKind ? treeherderConfig.jobKind : 'other',
       reason: treeherderConfig.reason || "scheduled",
       jobInfo: {
-        summary: task.metadata.description,
-        links: [
-          {
-            label: 'Inspect Task',
-            linkText: 'Inspect Task',
-            url: `https:\/\/tools.taskcluster.net/task-inspector/#${taskId}/${runId}`
-          },
-          {
-            label: 'One Click Loaner',
-            linkText: 'One Click Loaner',
-            url: `https:\/\/tools.taskcluster.net/one-click-loaner/#${taskId}`
-          }
-        ]
+        summary: task.metadata.description
       }
     };
 

--- a/test/fixtures/job_message.js
+++ b/test/fixtures/job_message.js
@@ -28,19 +28,7 @@ let message = `
     },
     "productName": "b2g",
     "jobInfo": {
-        "summary": "Dummy Task Description",
-        "links": [
-            {
-              "label": "Inspect Task",
-              "linkText": "Inspect Task",
-              "url": "https://tools.taskcluster.net/task-inspector/#5UMTRzgESFG3Bn8kCBwxxQ/0"
-            },
-            {
-              "label": "One Click Loaner",
-              "linkText": "One Click Loaner",
-              "url": "https://tools.taskcluster.net/one-click-loaner/#5UMTRzgESFG3Bn8kCBwxxQ"
-            }
-        ]
+        "summary": "Dummy Task Description"
     },
     "buildMachine": {
         "architecture": "-",


### PR DESCRIPTION
Treeherder now generates these links based on the taskid automatically