### PR TITLE
Bug 1431750 - add additionalProperties to schemas where missing

### DIFF
--- a/schemas/pulse-job.yml
+++ b/schemas/pulse-job.yml
@@ -42,6 +42,7 @@ properties:
   origin:
     oneOf:
       - type: "object"
+        additionalProperties: false
         title: "HG Push"
         properties:
           kind:
@@ -62,6 +63,7 @@ properties:
         required: [kind, project, revision]
 
       - type: "object"
+        additionalProperties: false
         title: "HG Push Legacy"
         description: |
           BACKWARD COMPATABILITY: An HG job that only has a revision_hash.
@@ -87,6 +89,7 @@ properties:
 
       - type: "object"
         title: "Github Pull Request"
+        additionalProperties: false
         properties:
           kind:
             type: "string"
@@ -114,6 +117,7 @@ properties:
 
   display:
     type: "object"
+    additionalProperties: false
     properties:
       jobSymbol:
         title: "jobSymbol"
@@ -377,12 +381,13 @@ properties:
                   - canceled
                   - unknown
             required:
-            - name
-            - timeStarted
-            - lineStarted
-            - lineFinished
-            - timeFinished
-            - result
+              - name
+              - timeStarted
+              - lineStarted
+              - lineFinished
+              - timeFinished
+              - result
+            additionalProperties: false
         errorsTruncated:
           type: boolean
           description: |
@@ -434,4 +439,4 @@ definitions:
       - platform
       - os
       - architecture
-
+    additionalProperties: false


### PR DESCRIPTION
Hey guys,

These changes are the ones I'm the least sure of across all our services - so I've requested two reviews to be safe! Basically, for the schemas I'm changing, I'm not sure if this is data we internally generate, or data we get back from treeherder. If we generate the data, we should set `"additionalProperties": false` and if we receive the data from treeherder, we should probably allow additional fields with `"additionalProperties": true` (so treeherder can introduce new fields in a backwardly compatible fashion).