### PR TITLE
Use old client to keep scheduler client for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lodash": "^4.12.0",
     "pulse-publisher": "^3.0.2",
     "slugid": "^1.1.0",
-    "taskcluster-client": "^3.1.1",
+    "taskcluster-client": "3.0.3",
     "taskcluster-lib-docs": "^4.1.1",
     "taskcluster-lib-loader": "^2.0.0",
     "taskcluster-lib-monitor": "^4.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1541,6 +1541,21 @@ superagent@~1.7.0:
     readable-stream "1.0.27-1"
     reduce-component "1.0.1"
 
+superagent@~3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.7.0.tgz#bd58bfde2cbc5305adb9ccbb6dacba18408629d6"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.1.1"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.0.5"
+
 superagent@~3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
@@ -1592,6 +1607,19 @@ tar-stream@^1.5.4:
     readable-stream "^2.0.0"
     xtend "^4.0.0"
 
+taskcluster-client@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-3.0.3.tgz#fbfb5fd87dcaf2fac280413dbb52ae51d2a812dc"
+  dependencies:
+    amqplib "^0.5.1"
+    babel-runtime "^6.26.0"
+    debug "^3.1.0"
+    hawk "^6.0.2"
+    lodash "^4.17.4"
+    promise "^8.0.1"
+    slugid "^1.1.0"
+    superagent "~3.7.0"
+
 taskcluster-client@^1.0.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-1.6.3.tgz#46e08445b7fcb590d4effb35df3f21bab0bb6da2"
@@ -1609,7 +1637,7 @@ taskcluster-client@^1.0.1:
   optionalDependencies:
     sockjs-client "^1.0.3"
 
-taskcluster-client@^3.0.3, taskcluster-client@^3.1.1:
+taskcluster-client@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-3.1.1.tgz#8420c269146d4be0774a49e6685a972d3ae40c59"
   dependencies:


### PR DESCRIPTION
```
Jan 19 11:42:26 taskcluster-treeherder app/handlers.1: Server crashed: TypeError: taskcluster.Scheduler is not a constructor 
Jan 19 11:42:26 taskcluster-treeherder app/handlers.1:     at setup (/app/src/main.js:86:23) 
Jan 19 11:42:26 taskcluster-treeherder app/handlers.1:     at /app/node_modules/taskcluster-lib-loader/lib/loader.js:337:28 
Jan 19 11:42:26 taskcluster-treeherder app/handlers.1:     at tryCallOne (/app/node_modules/promise/lib/core.js:37:12) 
Jan 19 11:42:26 taskcluster-treeherder app/handlers.1:     at /app/node_modules/promise/lib/core.js:123:15 
Jan 19 11:42:26 taskcluster-treeherder app/handlers.1:     at flush (/app/node_modules/asap/raw.js:50:29) 
Jan 19 11:42:26 taskcluster-treeherder app/handlers.1:     at _combinedTickCallback (internal/process/next_tick.js:131:7) 
Jan 19 11:42:26 taskcluster-treeherder app/handlers.1:     at process._tickDomainCallback (internal/process/next_tick.js:218:9) 
```