### PR TITLE
Bug 1154248 - don't include log links for exceptions or when a job is rerun

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -292,7 +292,9 @@ module.exports = class Handler {
     job.state = 'completed';
     job.result = 'fail';
     job.isRetried = true;
-    job.logs = [createLogReference(this.queue, message.status.taskId, run)];
+    // reruns often have no logs, so in the interest of not linking to a 404'ing artifact,
+    // don't include a link
+    job.logs = [];
     job = await addArtifactUploadedLinks(this.queue,
       this.monitor,
       message.status.taskId,
@@ -348,7 +350,9 @@ module.exports = class Handler {
     let job = this.buildMessage(pushInfo, task, message.runId, message);
     job.timeStarted = run.started;
     job.timeCompleted = run.resolved;
-    job.logs = [createLogReference(this.queue, message.status.taskId, run)];
+    // exceptions generally have no logs, so in the interest of not linking to a 404'ing artifact,
+    // don't include a link
+    job.logs = [];
     job = await addArtifactUploadedLinks(this.queue,
       this.monitor,
       message.status.taskId,

--- a/test/handle_task_exception_test.js
+++ b/test/handle_task_exception_test.js
@@ -51,12 +51,7 @@ suite('handle exception job', () => {
     expected.result = 'exception';
     expected.timeStarted = started.toISOString();
     expected.timeCompleted = resolved.toISOString();
-    expected.logs = [
-      {
-        name: 'builds-4h',
-        url: 'https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public/logs/live_backing.log', // eslint-disable-line max-len
-      },
-    ];
+    expected.logs = [];
 
     let job = await handler.handleTaskException(pushInfo, task, status);
     assert.deepEqual(actual, expected);
@@ -88,12 +83,7 @@ suite('handle exception job', () => {
     expected.result = 'superseded';
     expected.timeStarted = started.toISOString();
     expected.timeCompleted = resolved.toISOString();
-    expected.logs = [
-      {
-        name: 'builds-4h',
-        url: 'https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public/logs/live_backing.log', // eslint-disable-line max-len
-      },
-    ];
+    expected.logs = [];
 
     let job = await handler.handleTaskException(pushInfo, task, status);
     assert.deepEqual(actual, expected);
@@ -120,12 +110,7 @@ suite('handle exception job', () => {
       resolved: resolved.toISOString(),
     };
 
-    expected.logs = [
-      {
-        name: 'builds-4h',
-        url: 'https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public/logs/live_backing.log', // eslint-disable-line max-len
-      },
-    ];
+    expected.logs = [];
 
     let job = await handler.handleTaskException(pushInfo, task, status);
     assert.deepEqual(actual, undefined);

--- a/test/handle_task_rerun_test.js
+++ b/test/handle_task_rerun_test.js
@@ -45,12 +45,7 @@ suite('handle rerun job', () => {
     expected.state = 'completed';
     expected.result = 'fail';
     expected.isRetried = true;
-    expected.logs = [
-      {
-        name: 'builds-4h',
-        url: 'https://queue.taskcluster.net/v1/task/5UMTRzgESFG3Bn8kCBwxxQ/runs/0/artifacts/public/logs/live_backing.log', // eslint-disable-line max-len
-      },
-    ];
+    expected.logs = [];
 
     let job = await handler.handleTaskRerun(pushInfo, task, status);
     assert.deepEqual(actual, expected);


### PR DESCRIPTION
I *think* the rerun bit is for when e.g., run 0 when a run 1 is created.