### PR TITLE
Bug 1400258: Add support for generating `chain-of-trust` logs for treeherder.

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -49,19 +49,6 @@ function resultFromRun(run) {
   }
 }
 
-// Creates a log entry for Treeherder to retrieve and parse.  This log is
-// displayed on the Treeherder Log Viewer once parsed.
-function createLogReference(queue, taskId, run) {
-  let logUrl = `https://queue.taskcluster.net/v1/task/${taskId}` +
-               `/runs/${run.runId}/artifacts/public/logs/live_backing.log`;
-
-  return {
-    // XXX: This is a magical name see 1147958 which enables the log viewer.
-    name: 'builds-4h',
-    url: logUrl,
-  };
-}
-
 // Filters the task routes for the treeherder specific route.  Once found,
 // the route is parsed into distinct parts used for constructing the
 // Treeherder job message.
@@ -225,6 +212,7 @@ module.exports = class Handler {
       timeScheduled: task.created,
       jobKind: treeherderConfig.jobKind ? treeherderConfig.jobKind : 'other',
       reason: treeherderConfig.reason || 'scheduled',
+      logs: [],
       jobInfo: {
         links: [],
         summary: task.metadata.description,
@@ -316,7 +304,6 @@ module.exports = class Handler {
 
     job.timeStarted = run.started;
     job.timeCompleted = run.resolved;
-    job.logs = [createLogReference(this.queue, message.status.taskId, run)];
     job = await addArtifactUploadedLinks(this.queue,
       this.monitor,
       message.status.taskId,
@@ -330,7 +317,6 @@ module.exports = class Handler {
     let job = this.buildMessage(pushInfo, task, message.runId, message);
     job.timeStarted = run.started;
     job.timeCompleted = run.resolved;
-    job.logs = [createLogReference(this.queue, message.status.taskId, run)];
     job = await addArtifactUploadedLinks(this.queue,
       this.monitor,
       message.status.taskId,

--- a/src/transform/artifact_links.js
+++ b/src/transform/artifact_links.js
@@ -1,6 +1,12 @@
 const path = require('path');
 const taskcluster = require('taskcluster-client');
 
+LOG_ARTIFACTS = {
+    // XXX: This is a magical name see 1147958 which enables the log viewer.
+    'public/logs/live_backing.log': 'builds-4h',
+    'public/logs/chain_of_trust.log': 'chain-of-trust',
+}
+
 module.exports = async function(queue, monitor, taskId, runId, job) {
   let res;
   try {
@@ -28,6 +34,14 @@ module.exports = async function(queue, monitor, taskId, runId, job) {
   let seen = {};
 
   let links = artifacts.map((artifact) => {
+    let url = `https://queue.taskcluster.net/v1/task/${taskId}` +
+	       `/runs/${runId}/artifacts/${artifact.name}`;
+    if (artifact.name in LOG_ARTIFACTS) {
+	job.logs.push({
+	    name: LOG_ARTIFACTS[artifact.name],
+	    url: url,
+	});
+    }
     let name = path.parse(artifact.name).base;
     if (!seen[name]) {
       seen[name] = [artifact.name];
@@ -38,8 +52,7 @@ module.exports = async function(queue, monitor, taskId, runId, job) {
     let link = {
       label: 'artifact uploaded',
       linkText: name,
-      url: `https://queue.taskcluster.net/v1/task/${taskId}` +
-             `/runs/${runId}/artifacts/${artifact.name}`,
+      url: url,
     };
     return link;
   });


### PR DESCRIPTION
This works with mozilla/treeherder#3615 to provide both scriptwork logs as treeherder logs. Unfortunately, treeherder doesn't have good support for multiple logs yet. 