### PR TITLE
The property is named symbol, not jobSymbol

### DIFF
--- a/schemas/v1/task-treeherder-config.yml
+++ b/schemas/v1/task-treeherder-config.yml
@@ -93,10 +93,10 @@ properties:
       minLength: 1
       maxLength: 50
       pattern: "^[A-Za-z0-9_-]+$"
-  jobSymbol:
-    title: "jobSymbol"
+  symbol:
+    title: "symbol"
     description: |
-      Job Symbol is the symbol that will appear in a Treeherder resultset for a
+      This is the symbol that will appear in a Treeherder resultset for a
       given push.  This symbol could be something such as "B" or a number representing
       the current chunk.
     type: "string"


### PR DESCRIPTION
Note that the schema ends with `required: [symbol]`.  Checking the code,
it uses `symbol` and does not ever look at `jobSymbol`.